### PR TITLE
Switch to frontside.com domain

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Shared eslint config @thefrontside",
   "main": "index.js",
   "repository": "https://github.com/thefrontside/eslint-config",
-  "author": "Frontside Engineering <engineering@frontside.io>",
+  "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "private": false,
   "keywords": ["eslint", "eslintconfig"]


### PR DESCRIPTION
`frontside.io` ➡️ `frontside.com`